### PR TITLE
Update preinst

### DIFF
--- a/android-studio-5.2.1/debian/preinst
+++ b/android-studio-5.2.1/debian/preinst
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# install some dependencies
+sudo apt-get install lib32stdc++6 zlib1g zlib1g:i386
+
 cd /opt/
 
 ## Download Android Studio from Google's Servers.


### PR DESCRIPTION
- Installation of android studio failed and was fixed after installing `lib32stdc++6`
- android studio gave the error `"~/Android/Sdk/build-tools/23.0.2/aapt": finished with non-zero exit value 127` when compiling a project on Ubuntu 16.04. This was fixed by installing `zlib1g zlib1g:i386` so I'm adding these in the preinst file.
