### PR TITLE
Improve Java SDK dependency

### DIFF
--- a/android-studio-5.2.1/debian/control
+++ b/android-studio-5.2.1/debian/control
@@ -8,7 +8,6 @@ Standards-Version: 3.9.5
 
 Package: android-studio
 Architecture: all
-Suggest: default-jdk
-Depends: ${misc:Depends}, java-sdk | oracle-java7-installer | oracle-java8-installer, unzip
+Depends: ${misc:Depends}, default-jdk | java-sdk | oracle-java7-installer | oracle-java8-installer, unzip
 Description: Android Studio.
  Integrated Android developer tools for development and debugging.


### PR DESCRIPTION
Current behavior:
The current Depends: field causes apt to install a JDK that might not be the default-jdk when the user has no JDK installed. On Ubuntu Xenial and Yaketty this will cause OpenJDK 9 to be installed, which is not optimal given that OpenJDK 9 has not been released yet.

Expected result:
Installing android-studio should cause the distro's recommended JDK (ie. default-jdk) to be installed when the user has no JDK installed. If the user already has a JDK installed, then android-studio should use it. This can be achieved by adding "default-jdk" to the "Depends:" field while still keeping the java-sdk dependency for when the user has another JDK installed.